### PR TITLE
Remove __call method from trait (breaking change)

### DIFF
--- a/src/Eavquent.php
+++ b/src/Eavquent.php
@@ -430,14 +430,16 @@ trait Eavquent
      * @param  array $parameters
      * @return mixed
      */
-    public function __call($method, $parameters)
+    public function eavquentMagicMethodCall($method, $parameters)
     {
         $this->bootEavquentIfNotBooted();
 
         if ($this->isAttributeRelation($method)) {
             return call_user_func_array($this->attributeRelations[$method], $parameters);
         }
+        else {
+            return false;
+        }
 
-        return parent::__call($method, $parameters);
     }
 }

--- a/tests/support/models/Company.php
+++ b/tests/support/models/Company.php
@@ -12,7 +12,7 @@ class Company extends Model
     
     public function __call($method, $parameters)
     {
-        if($eav_call = $this->eavquentMagicMethodCall($method,$parameters)) return $eav_call;
+        if ($eav_call = self::eavquentMagicMethodCall($method, $parameters)) return $eav_call;
        
         //if($other_package_call = $this->otherPackageMagicMethodCall($method,$parameters)) return $other_package_call;
        

--- a/tests/support/models/Company.php
+++ b/tests/support/models/Company.php
@@ -9,5 +9,14 @@ class Company extends Model
     protected $fillable = ['name'];
 
     public $timestamps = false;
+    
+    public function __call($method, $parameters)
+    {
+        if($eav_call = $this->eavquentMagicMethodCall($method,$parameters)) return $eav_call;
+       
+        //if($other_package_call = $this->otherPackageMagicMethodCall($method,$parameters)) return $other_package_call;
+       
+        return parent::__call($method, $parameters);
+    }
 
 }


### PR DESCRIPTION
Defining a __call method in the trait opens up the application to the possibility of conflicts. If any other trait wants to use the __call method, the a fatal error is fired due to collision.

I think it would be better to override __call in the model using the Eavquent trait, so you leave open the possibility of packages other than Eavquent using magic methods as well.

This is a breaking change, and models using Eavquent would need to be updated with the following method:

```
public function __call($method, $parameters)
    {
        if($eav_call = $this->eavquentMagicMethodCall($method,$parameters)) return $eav_call;
       
        //if($other_package_call = $this->otherPackageMagicMethodCall($method,$parameters)) return $other_package_call;
        return parent::__call($method, $parameters);
    }
```
Please let me know your thoughts
